### PR TITLE
fix(sonar): use locked uv sync and safer CI installs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - run: uv run pytest tests-int
+      - run: uv sync --locked --no-dev --no-editable --no-build
+      - run: uv run --no-sync pytest tests-int

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - run: uv run pytest tests --cov=src --cov-fail-under=100 --cov-report json
+      - run: uv sync --locked --no-dev --no-editable --no-build
+      - run: uv run --no-sync pytest tests --cov=src --cov-fail-under=100 --cov-report json
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
@@ -48,8 +49,9 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - run: uv run mypy
-      - run: uv run pylint src
+      - run: uv sync --locked --no-dev --no-editable --no-build
+      - run: uv run --no-sync mypy
+      - run: uv run --no-sync pylint src
 
   lint:
     name: Lint
@@ -61,5 +63,6 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-      - run: uv run black --check .
-      - run: uv run isort --check .
+      - run: uv sync --locked --no-dev --no-editable --no-build
+      - run: uv run --no-sync black --check .
+      - run: uv run --no-sync isort --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm run release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV UV_LINK_MODE=copy \
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-dev --no-install-project
+    uv sync --locked --no-dev --no-install-project --no-build
 
 COPY ./src /src
 
@@ -29,7 +29,7 @@ COPY ./src /src
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable --no-build
 
 FROM python AS app
 


### PR DESCRIPTION
## Summary
- Sync dependencies explicitly with `--locked --no-build` before `uv run --no-sync` in CI workflows
- Add `--ignore-scripts` to release workflow pnpm install
- Add `--no-build` to Dockerfile `uv sync` steps

Resolves githubactions:S6505, S8541, S8544, and docker:S8541.

## Test plan
- [ ] Python and integration CI jobs pass
- [ ] Docker build succeeds
- [ ] SonarCloud quality gate improves after merge

Made with [Cursor](https://cursor.com)